### PR TITLE
Return the focus after generation process

### DIFF
--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 interface InputAreaProps {
   onSendMessage: (input: string) => Promise<void>;
@@ -8,6 +8,7 @@ interface InputAreaProps {
 
 const InputArea: React.FC<InputAreaProps> = ({ onSendMessage, isGenerating, isModelLoaded }) => {
   const [input, setInput] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleSend = () => {
     if (input.trim() && !isGenerating && isModelLoaded) {
@@ -15,6 +16,12 @@ const InputArea: React.FC<InputAreaProps> = ({ onSendMessage, isGenerating, isMo
       setInput('');
     }
   };
+
+  useEffect(() => {
+    if (!isGenerating && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isGenerating]);
 
   const isSendDisabled = !isModelLoaded || isGenerating || !input.trim();
 
@@ -29,6 +36,7 @@ const InputArea: React.FC<InputAreaProps> = ({ onSendMessage, isGenerating, isMo
           disabled={!isModelLoaded || isGenerating}
           className="flex-grow p-3 rounded-lg bg-[var(--bg-color)] focus:outline-none focus:ring-2 focus:[var(--border-color)] text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
           onKeyPress={(e) => e.key === 'Enter' && !isSendDisabled && handleSend()}
+          ref={inputRef}
         />
         <button
           onClick={handleSend}


### PR DESCRIPTION
This pull request enhances the `InputArea` component in `src/components/InputArea.tsx` to improve user experience by managing focus and handling user input more effectively. The most important changes include adding focus management using `useRef` and `useEffect`, and updating the input element to use the reference.

Focus management improvements:

* [`src/components/InputArea.tsx`](diffhunk://#diff-80a8b7bc92cfb82976df173fadd9bd5f54be2becd28ae2ceeffc12fa1b782f19L1-R1): Imported `useRef` and `useEffect` from React to manage input focus.
* [`src/components/InputArea.tsx`](diffhunk://#diff-80a8b7bc92cfb82976df173fadd9bd5f54be2becd28ae2ceeffc12fa1b782f19R11): Added `inputRef` using `useRef` to reference the input element.
* [`src/components/InputArea.tsx`](diffhunk://#diff-80a8b7bc92cfb82976df173fadd9bd5f54be2becd28ae2ceeffc12fa1b782f19R20-R25): Implemented `useEffect` to focus the input when `isGenerating` is false.
* [`src/components/InputArea.tsx`](diffhunk://#diff-80a8b7bc92cfb82976df173fadd9bd5f54be2becd28ae2ceeffc12fa1b782f19R39): Added `ref={inputRef}` to the input element to connect it with the reference.